### PR TITLE
Fixed a path to the source file in the template to use an attribute value

### DIFF
--- a/templates/default/nvm.sh.erb
+++ b/templates/default/nvm.sh.erb
@@ -1,5 +1,5 @@
 <% if @user_install %>
   [ -f ${HOME}/.nvm/nvm.sh ] && . ${HOME}/.nvm/nvm.sh
 <% else %>
-[ -f /usr/local/src/nvm/nvm.sh ] && . /usr/local/src/nvm/nvm.sh
+[ -f <%= node['nvm']['directory'] %>/nvm.sh ] && . <%= node['nvm']['directory'] %>/nvm.sh
 <% end %>


### PR DESCRIPTION
When install as system wide, the source file path is fixed to `/usr/local/src/nvm/nvm.sh`. But there is the appropriate value to use in the attribute file.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/phutchins/nvm/3)

<!-- Reviewable:end -->
