### PR TITLE
Added support for CentOS

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,6 +1,7 @@
 ---
 driver_plugin: vagrant
 driver_config:
+  require_chef_omnibus: 11.6.0
   customize:
     memory: 1024
 
@@ -9,29 +10,40 @@ platforms:
   driver_config:
     box: opscode-ubuntu-12.04-nochef
     box_url: https://opscode-vm.s3.amazonaws.com/vagrant/opscode_ubuntu-12.04_provisionerless.box
-    require_chef_omnibus: 11.6.0
     network:
       - ["private_network", {ip: "11.12.14.11"}]
   run_list:
   - recipe[apt]
+- name: centos-6.5
+  driver_config:
+    box: opscode_centos-6.5_chef
+    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.5_chef-provisionerless.box
+    network:
+      - ["private_network", {ip: "11.12.14.12"}]
 
 suites:
 - name: default
   run_list:
     - recipe[nvm_test::default]
     - recipe[minitest-handler]
+  excludes:
+    - centos-6.5
+
 - name: nvm-install-global
   run_list:
     - recipe[nvm_test::nvm_install_global]
     - recipe[minitest-handler]
+
 - name: nvm-alias-default
   run_list:
     - recipe[nvm_test::nvm_alias_default]
     - recipe[minitest-handler]
+
 - name: nvm-install-from-source
   run_list:
     - recipe[nvm_test::nvm_install_from_source]
     - recipe[minitest-handler]
+
 - name: nvm-install-user
   run_list:
     - recipe[nvm_test::nvm_install_user]

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -20,6 +20,7 @@ GRAPH
   minitest-handler (0.2.1)
     chef_handler (>= 0.0.0)
   nvm (0.1.6)
+    build-essential (>= 0.0.0)
     git (>= 2.1.0)
   nvm_test (0.1.0)
     nvm (>= 0.0.0)

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      "Installs nvm, the node version manager"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 supports 		 'ubuntu', ">= 12.04"
 supports     'centos', ">= 6.5"
-version          "0.1.6"
+version          "0.1.7"
 
 depends "git", ">= 2.1.0"
 depends "build-essential"

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,6 +5,8 @@ license          "Apache 2.0"
 description      "Installs nvm, the node version manager"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 supports 		 'ubuntu', ">= 12.04"
+supports     'centos', ">= 6.5"
 version          "0.1.6"
 
 depends "git", ">= 2.1.0"
+depends "build-essential"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,21 +20,33 @@
 include_recipe 'git'
 
 ############################################################################
+
 # Install dependencies
-
-package 'libcurl3' do
-  action :install
-end
-
-package 'curl' do
-  action :install
-end
-
-if node['nvm']['install_deps_to_build_from_source']
-  package 'build-essential' do
+case node[:platform]
+when "debian"
+  package 'libcurl3' do
     action :install
   end
-  package 'libssl-dev' do
+
+  package 'curl' do
     action :install
   end
+
+  if node['nvm']['install_deps_to_build_from_source']
+    package 'build-essential' do
+      action :install
+    end
+
+    package 'libssl-dev' do
+      action :install
+    end
+  end
+
+when "centos"
+  if node['nvm']['install_deps_to_build_from_source']
+    include_recipe 'build-essential'
+  end
+
+else
+  Chef::Log.warn "Platform not supported."
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,8 +22,8 @@ include_recipe 'git'
 ############################################################################
 
 # Install dependencies
-case node[:platform]
-when "debian"
+case node['platform_family']
+when 'debian'
   package 'libcurl3' do
     action :install
   end
@@ -42,7 +42,7 @@ when "debian"
     end
   end
 
-when "centos"
+when 'rhel'
   if node['nvm']['install_deps_to_build_from_source']
     include_recipe 'build-essential'
   end


### PR DESCRIPTION
Hi
I ran the test suites using a CentOS box and it works smoothly and all tests passed, except for the "default" which asserts that libcurl3 package is installed (that doesn't exists on CentOS).

Could you please review it? I really would like to see it working on CentOS platforms.
