### PR TITLE
Add retries for git sync to handle github timeouts.

### DIFF
--- a/providers/install.rb
+++ b/providers/install.rb
@@ -62,6 +62,8 @@ action :create do
     group chef_nvm_group
     repository node['nvm']['repository']
     reference node['nvm']['reference']
+    retries 5
+    retry_delay 5
     action :sync
   end
 


### PR DESCRIPTION
We sometimes get timeouts from github.com at this step of the cookbook, which causes our chef runs to fail. This can alleviate that problem.
