### PR TITLE
Don't access remote git repository if it's already checked out.

### DIFF
--- a/providers/install.rb
+++ b/providers/install.rb
@@ -65,6 +65,7 @@ action :create do
     retries 5
     retry_delay 5
     action :sync
+    not_if { ::File.exists?(nvm_dir + "/.git") }
   end
 
   template '/etc/profile.d/nvm.sh' do


### PR DESCRIPTION
The rationale for this change stems from GitHub's major outage last night. We install nvm on newly provisioning EC2 instances using this cookbook.  Because it hits github even if nvm is already installed, we were unable to bring up any new EC2 instances.

Adding this line saved us, because our base AMI for our EC2 instances already had nvm installed.
